### PR TITLE
Uzi eksplicite Python 2.

### DIFF
--- a/espdic/Makefile
+++ b/espdic/Makefile
@@ -1,5 +1,5 @@
 all:
-	python ./convert-to-js.py
+	python2 ./convert-to-js.py
 
 clean:
 	rm -f espdic.js

--- a/etymology/Makefile
+++ b/etymology/Makefile
@@ -1,5 +1,5 @@
 all:
-	python ./convert-to-js.py
+	python2 ./convert-to-js.py
 
 clean:
 	rm -f etymology.js

--- a/revo/Makefile
+++ b/revo/Makefile
@@ -1,5 +1,5 @@
 all:
-	python ./convert-to-js.py
+	python2 ./convert-to-js.py
 
 clean:
 	rm -f revo-*

--- a/transitiveco/Makefile
+++ b/transitiveco/Makefile
@@ -1,5 +1,5 @@
 all:
-	python ./convert-to-js.py
+	python2 ./convert-to-js.py
 
 clean:
 	rm -f transitiveco.js


### PR DESCRIPTION
En sistemo ke havas Python 3 la `Makefile` donas eraroj ĉar en Python 3 la funkcio `print` uzas las `()`. Sed, por ke sistemo ke ne havas Python 3 podas uzi la kodo, mi ŝanĝi la `Makefile` por ke ĝi uzos eksplicite Python 2 anstataŭ Python 3.